### PR TITLE
Added "intents" - Fixed the script again :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ Before running the bot from `bot_main.py`, you must set a few options in `settin
 * `server_working_directory`: the place where you want all the server's files (e.g. map, server.properties, etc.) are.
 * `bot_token`: the bot token you got from [Discord's "My Apps page"](https://discordapp.com/developers/applications/me)
 
-On Windows devices you must use double backslashes in your file and directory paths. otherwise the slashes will be treated as escape characters.
+  * Windows users must use double backslashes their file paths, single backslashes will be treated as escape characters.
+* Make sure to allow `Message Content Intent` in the Developer Portal under the `Bot` section!

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Discord bot that listens for a trigger phrase that will cause it to run a Mine
 
 ## Dependencies
 * Python3 version **after** 3.8, because discord.py requires it.
-* [discord.py](https://github.com/Rapptz/discord.py), the Discord API wrapper used. This bot has been tested on v1.7.3.
+* [discord.py](https://github.com/Rapptz/discord.py), the Discord API wrapper used. This bot has been tested on v2.0.1.
 
 ## Setup
 Before running the bot from `bot_main.py`, you must set a few options in `settings.json`:

--- a/bot_main.py
+++ b/bot_main.py
@@ -4,6 +4,9 @@ import json
 import asyncio
 import threading
 
+#new requirement: explicit intents
+intents = discord.Intents.default()
+
 #load the settings
 with open('settings.json', 'r') as settings_file:
     settings_json = settings_file.read()

--- a/bot_main.py
+++ b/bot_main.py
@@ -5,6 +5,7 @@ import asyncio
 import threading
 
 intents = discord.Intents.default()
+intents.message_content = True
 
 #load the settings
 with open('settings.json', 'r') as settings_file:

--- a/bot_main.py
+++ b/bot_main.py
@@ -4,7 +4,6 @@ import json
 import asyncio
 import threading
 
-#new requirement: explicit intents
 intents = discord.Intents.default()
 
 #load the settings
@@ -15,7 +14,7 @@ with open('settings.json', 'r') as settings_file:
 
 #set up the bot
 os.chdir(bot_settings['server_working_directory'])
-bot = discord.Client()
+bot = discord.Client(intents=intents)
 server_thread = None
 
 @bot.event


### PR DESCRIPTION
Implemented the new requirements for [intents](https://discordpy.readthedocs.io/en/stable/migrating.html#intents-are-now-required) and[ privileged intents](https://discord.com/developers/docs/topics/gateway#privileged-intents).


Commits are a bit messy as I was testing the script in the mean time, what it comes down to is:
* two new lines listing the default intent and the `message_content` privileged intent (lines 8 & 9)
* one edited line: `bot = discord.Client()` has become `bot = discord.Client(intents = intents)` (line 19)
* edited the README accordingly:
  * upped the "tested" discord.py version
  * added the extra step of toggling `message_content` intent
  * shortened the windows double backslash problem